### PR TITLE
Export TS files

### DIFF
--- a/packages/package-one/package.json
+++ b/packages/package-one/package.json
@@ -4,10 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
   "scripts": {
     "dev": "tsc --watch",

--- a/packages/package-three/package.json
+++ b/packages/package-three/package.json
@@ -4,10 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
   "scripts": {
     "dev": "tsc --watch",

--- a/packages/package-three/src/index.ts
+++ b/packages/package-three/src/index.ts
@@ -1,8 +1,4 @@
 import { schema } from "package-two";
 
-const yos = schema.parse([
-  { id: "1", name: "yo" },
-  { id: "2", name: "yo" },
-]);
-
-yos.map((yo) => yo.id);
+const yo = schema.parse({ id: "1", name: "yo" });
+const id = yo.id;

--- a/packages/package-two/package.json
+++ b/packages/package-two/package.json
@@ -4,10 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
   "scripts": {
     "dev": "tsc --watch",


### PR DESCRIPTION
The fix I came up for this was to export the Typescript files directly rather than the transpiled Javascript files. 

In a monorepo environment, this is the recommended practice (e.g. see the [`exports` example on Turborepo docs](https://turbo.build/repo/docs/crafting-your-repository/structuring-a-repository#exports) and the example repo created by running `npx create-turbo@latest`)

This wouldn't be a valid fix if you actually want to import the transpiled JS files rather than the TS files but I'm not sure why that'd be desired (but let me know if you do have reasons!)

I also changed `package-three/src/index.ts` because the schema is for an object but the original repo tries to parse an array which doesn't make sense.

(This solution doesn't explain why package-two is generated with inlined `import("zod")` so if your goal was to understand what's going on there rather than resolve the type error, it's totally fine if you don't consider this is a fix. :P)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified module exports for multiple packages, now directly pointing to TypeScript source files.
  
- **Bug Fixes**
	- Improved data parsing by transitioning from an array of objects to a single object, enhancing clarity and control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->