### PR TITLE
export and use types explicitly

### DIFF
--- a/packages/package-one/src/index.ts
+++ b/packages/package-one/src/index.ts
@@ -4,3 +4,5 @@ export const schema = z.object({
   id: z.string(),
   name: z.string(),
 });
+
+export type SchemaType = z.infer<typeof schema>;

--- a/packages/package-three/src/index.ts
+++ b/packages/package-three/src/index.ts
@@ -1,6 +1,7 @@
 import { schema } from "package-two";
+import type { schemaType } from "package-two";
 
-const yos = schema.parse([
+const yos: schemaType[] = schema.parse([
   { id: "1", name: "yo" },
   { id: "2", name: "yo" },
 ]);

--- a/packages/package-two/src/index.ts
+++ b/packages/package-two/src/index.ts
@@ -1,3 +1,4 @@
-import { schema as packageOneSchema } from "package-one";
+import { schema as packageOneSchema, type SchemaType as packageOneSchemaType } from "package-one";
 
 export const schema = packageOneSchema;
+export type schemaType = packageOneSchemaType;


### PR DESCRIPTION
tried exporting types from package-one and using explicitly in package-three.

this is a workaround obviously and I thought it might help (still learning TS btw!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new type alias `SchemaType` for enhanced type safety in data handling.
	- Added `packageOneSchemaType` to expand type definitions in the current module.
	- Enhanced public API with the new `schemaType` export for better clarity and type safety.

- **Improvements**
	- Explicitly declared type for `yos` constant to ensure it aligns with expected data structure, improving documentation and compile-time checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->